### PR TITLE
🎨 Decoupled the installation from local cloning

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ You can, however, use additional arguments such as **-w** or **-l** to show menu
 
 #### Usage:
 
-After cloning this repository, navigate to its directory, and run:
+To setup everything, just run:
 ```
-./install.sh
+wget https://raw.githubusercontent.com/GLUA-UA/meals-ua/master/install.sh -O - | sh
 ```
 Which installs the necessary dependencies and places a symlink in **$HOME/.local/bin**
 

--- a/install.sh
+++ b/install.sh
@@ -17,10 +17,10 @@ if [[ ${PATH} != *"${HOME}/.local/bin"* ]]; then
 	echo "PATH DEFAULT=\${PATH}:/home/@{PAM_USER}/.local/bin" >> $HOME/.pam_environment
   echo "Relog and the rerun ./install.sh"
 else
-  ## Install Python dependencies
-  pip3 install --user -r requirements.txt # Install dependencies
+	## install python dependencies from remote requirements.txt
+	wget -O - https://raw.githubusercontent.com/GLUA-UA/meals-ua/master/requirements.txt | xargs pip3 install --user 
 
-  chmod +x meals-ua.py
-
-  ln -s $(pwd)/meals-ua.py ${INSTALL_DIR}/ementas
+	## get the ementas script and set permissions
+	wget https://raw.githubusercontent.com/GLUA-UA/meals-ua/master/meals-ua.py -O $HOME/.local/bin/ementas
+	chmod +x $HOME/.local/bin/ementas
 fi


### PR DESCRIPTION
Right now, one has to clone the remote repo, cd into it and only then install. With this change one is able to simply run the install script from a remote source, explained in the updated README.md, and the script does the rest without cloning by pulling files with wget (no need to cleanup thanks to -O flag).

This, in my opinion, solves https://github.com/GLUA-UA/meals-ua/pull/8 and in regards to updates one can just re-run the command specified in this commit's README.md and always keep up the the main repo's master branch. It also makes it easier for non-developing users to have this running (given that there's no need to clone and install from that dir).